### PR TITLE
GCamGOPrebuilt: Add GCamGOPrebuilt-V3_8

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -8,7 +8,7 @@ android_app_import {
 	},
 	privileged: true,
 	product_specific: true,
-	overrides: ["Camera2", "GCamGOPrebuilt-V2", "GCamGOPrebuilt-V3", "Snap"],
+	overrides: ["Camera2", "GCamGOPrebuilt-V2", "GCamGOPrebuilt-V3", "GCamGOPrebuilt-V3_8","Snap"],
 }
 
 android_app_import {
@@ -21,7 +21,7 @@ android_app_import {
 	},
 	privileged: true,
 	product_specific: true,
-	overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V3", "Snap"],
+	overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V3", "GCamGOPrebuilt-V3_8", "Snap"],
 }
 
 android_app_import {
@@ -34,5 +34,18 @@ android_app_import {
 	},
 	privileged: true,
         product_specific: true,
-        overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V2", "Snap"],
+        overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V2", "GCamGOPrebuilt-V3_8", "Snap"],
+}
+
+android_app_import {
+        name: "GCamGOPrebuilt-V3_8",
+        owner: "google",
+        apk: "GCamGOPrebuilt-V3.apk",
+        presigned: true,
+        dex_preopt: {
+		enabled: false,
+	},
+	privileged: true,
+        product_specific: true,
+        overrides: ["Camera2", "GCamGOPrebuilt", "GCamGOPrebuilt-V2", "GCamGOPrebuilt-V3", "Snap"],
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ PRODUCT_PACKAGES += \
     GCamGOPrebuilt
 ```
 
+## Latest GCamGOPrebuilt packages (Stable)
+```
+PRODUCT_PACKAGES += \
+    GCamGOPrebuilt-V3_8
+```
+
 ## Latest GCamGOPrebuilt packages (Experimental)
 ```
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Add GCamGOPrebuilt-V3_8 from SGCAM_GO_3.8.47_STABLE_V1.apk (com.google.android.apps.cameralite)

Source: https://www.celsoazevedo.com/files/android/google-camera/camerago/
Change-Id: Ida837094710edede4910bfc582fe7407f66117be